### PR TITLE
Check for "system" theme when appending darkmode

### DIFF
--- a/src/utils/ThemeProviderUtils.ts
+++ b/src/utils/ThemeProviderUtils.ts
@@ -2,5 +2,6 @@ import { useTheme } from "../components/theme-provider";
 
 export function isDarkModeSet(): boolean {
   const { theme } = useTheme();
-  return theme === "dark";
+
+  return theme === "dark" || theme === "system";
 }


### PR DESCRIPTION
Fixes the issue where darkmode would return wrong images if the theme preferences are set to system